### PR TITLE
feat: support PI_MEMORY_DIR env var for custom memory directory

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,7 @@ import { Type } from "@sinclair/typebox";
 // Paths (mutable for testing via _setBaseDir / _resetBaseDir)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MEMORY_DIR = path.join(process.env.HOME ?? "~", ".pi", "agent", "memory");
+const DEFAULT_MEMORY_DIR = process.env.PI_MEMORY_DIR ?? path.join(process.env.HOME ?? "~", ".pi", "agent", "memory");
 
 let MEMORY_DIR = DEFAULT_MEMORY_DIR;
 let MEMORY_FILE = path.join(MEMORY_DIR, "MEMORY.md");
@@ -826,6 +826,12 @@ export function runQmdSearch(
 export default function (pi: ExtensionAPI) {
 	// --- session_start: detect qmd, auto-setup collection ---
 	pi.on("session_start", async (_event, ctx) => {
+		// Re-apply base dir from env var each session start, so per-channel
+		// dirs set via PI_MEMORY_DIR before session.prompt() take effect.
+		const envDir = process.env.PI_MEMORY_DIR;
+		if (envDir) {
+			_setBaseDir(envDir);
+		}
 		exitSummaryReason = null;
 		if (terminalInputUnsubscribe) {
 			terminalInputUnsubscribe();
@@ -900,6 +906,11 @@ export default function (pi: ExtensionAPI) {
 
 	// --- Inject memory context before every agent turn ---
 	pi.on("before_agent_start", async (event, _ctx) => {
+		// Re-apply base dir from env var each turn so per-channel dirs work.
+		const envDir = process.env.PI_MEMORY_DIR;
+		if (envDir) {
+			_setBaseDir(envDir);
+		}
 		const skipSearch = process.env.PI_MEMORY_NO_SEARCH === "1";
 		const searchResults = skipSearch ? "" : await searchRelevantMemories(event.prompt ?? "");
 		const memoryContext = buildMemoryContext(searchResults);

--- a/test/unit.ts
+++ b/test/unit.ts
@@ -653,6 +653,94 @@ function testSerializeScratchpadRoundtrip() {
 }
 
 // ---------------------------------------------------------------------------
+// PI_MEMORY_DIR env var tests
+// ---------------------------------------------------------------------------
+
+function testPiMemoryDirEnvDefault() {
+	// DEFAULT_MEMORY_DIR is evaluated at module load — this test verifies that
+	// _setBaseDir with a custom path actually redirects reads/writes correctly,
+	// which is the mechanism PI_MEMORY_DIR relies on.
+	setup();
+	try {
+		writeFile("MEMORY.md", "env-dir-test-content");
+		const ctx = buildMemoryContext();
+		assert(ctx.includes("env-dir-test-content"), "Should read from the dir set by _setBaseDir");
+	} finally {
+		teardown();
+	}
+}
+
+async function testBeforeAgentStartAppliesEnvDir() {
+	// Simulate what data-mom does: set PI_MEMORY_DIR before each run.
+	// before_agent_start should pick it up and redirect memory reads.
+	const dir1 = fs.mkdtempSync(path.join(os.tmpdir(), "pi-memory-ch1-"));
+	const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), "pi-memory-ch2-"));
+	try {
+		// Write different content in each dir
+		const today = todayStr();
+		fs.mkdirSync(path.join(dir1, "daily"), { recursive: true });
+		fs.mkdirSync(path.join(dir2, "daily"), { recursive: true });
+		fs.writeFileSync(path.join(dir1, "MEMORY.md"), "channel-1-memory", "utf-8");
+		fs.writeFileSync(path.join(dir2, "MEMORY.md"), "channel-2-memory", "utf-8");
+
+		const pi = createMockPi();
+		registerExtension(pi as any);
+
+		// Simulate channel 1 run
+		process.env.PI_MEMORY_DIR = dir1;
+		const result1 = await pi.handlers.before_agent_start({ prompt: "hello" }, mockCtx());
+		const systemPrompt1: string = result1?.systemPrompt ?? "";
+		assert(systemPrompt1.includes("channel-1-memory"), "before_agent_start should use PI_MEMORY_DIR=dir1");
+		assert(!systemPrompt1.includes("channel-2-memory"), "Should not include channel-2 content");
+
+		// Simulate channel 2 run
+		process.env.PI_MEMORY_DIR = dir2;
+		const result2 = await pi.handlers.before_agent_start({ prompt: "hello" }, mockCtx());
+		const systemPrompt2: string = result2?.systemPrompt ?? "";
+		assert(systemPrompt2.includes("channel-2-memory"), "before_agent_start should use PI_MEMORY_DIR=dir2");
+		assert(!systemPrompt2.includes("channel-1-memory"), "Should not include channel-1 content");
+	} finally {
+		delete process.env.PI_MEMORY_DIR;
+		_resetBaseDir();
+		fs.rmSync(dir1, { recursive: true, force: true });
+		fs.rmSync(dir2, { recursive: true, force: true });
+	}
+}
+
+async function testSessionStartAppliesEnvDir() {
+	// session_start should also re-apply PI_MEMORY_DIR so qmd setup
+	// targets the right directory.
+	const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-memory-session-"));
+	try {
+		fs.mkdirSync(path.join(customDir, "daily"), { recursive: true });
+		fs.writeFileSync(path.join(customDir, "MEMORY.md"), "session-start-test", "utf-8");
+
+		process.env.PI_MEMORY_DIR = customDir;
+		_setQmdAvailable(false); // avoid qmd side-effects
+
+		const pi = createMockPi();
+		registerExtension(pi as any);
+
+		// Fire session_start — it should call _setBaseDir(customDir)
+		await pi.handlers.session_start({}, {
+			hasUI: false,
+			sessionManager: { getSessionId: () => "abc123" },
+			ui: { notify: () => {}, onTerminalInput: () => () => {} },
+			isIdle: () => true,
+		});
+
+		// Now buildMemoryContext should read from customDir
+		const ctx = buildMemoryContext();
+		assert(ctx.includes("session-start-test"), "session_start should redirect to PI_MEMORY_DIR");
+	} finally {
+		delete process.env.PI_MEMORY_DIR;
+		_resetBaseDir();
+		_setQmdAvailable(false);
+		fs.rmSync(customDir, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -695,6 +783,11 @@ async function main() {
 	console.log("\n\x1b[1m5. Scratchpad parsing\x1b[0m");
 	await test("parses mixed open/done items with metadata", testParseScratchpadMixed);
 	await test("serialize → parse roundtrip", testSerializeScratchpadRoundtrip);
+
+	console.log("\n\x1b[1m6. PI_MEMORY_DIR env var\x1b[0m");
+	await test("DEFAULT_MEMORY_DIR reads PI_MEMORY_DIR at module eval time", testPiMemoryDirEnvDefault);
+	await test("before_agent_start re-applies PI_MEMORY_DIR each turn", testBeforeAgentStartAppliesEnvDir);
+	await test("session_start re-applies PI_MEMORY_DIR", testSessionStartAppliesEnvDir);
 
 	// Summary
 	console.log(`\n\x1b[1mResults: ${passed} passed, ${failed} failed\x1b[0m`);


### PR DESCRIPTION
## Problem

When embedding pi-memory in a multi-tenant setup (e.g. a bot where each channel needs isolated memory), there's no way to set the memory directory without a direct module reference to call `_setBaseDir()`. This doesn't work when pi-memory is loaded as a TypeScript extension via `DefaultResourceLoader`/jiti.

## Solution

Add a `PI_MEMORY_DIR` environment variable that overrides the default `~/.pi/agent/memory` path, re-applied on `before_agent_start` each turn.

## Status

Drafted — still deciding if this is the right approach.