### PR TITLE
fix: prevent path traversal in memory_read daily date

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,19 @@ export function readFileSafe(filePath: string): string | null {
 	}
 }
 
+const DAILY_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidDailyDate(date: string): boolean {
+	if (!DAILY_DATE_REGEX.test(date)) return false;
+	const [year, month, day] = date.split("-").map(Number);
+	const parsed = new Date(Date.UTC(year, month - 1, day));
+	return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
+}
+
 export function dailyPath(date: string): string {
+	if (!isValidDailyDate(date)) {
+		throw new Error(`Invalid daily date: ${date}. Expected YYYY-MM-DD.`);
+	}
 	return path.join(DAILY_DIR, `${date}.md`);
 }
 
@@ -1322,6 +1334,13 @@ export default function (pi: ExtensionAPI) {
 
 			if (target === "daily") {
 				const d = date ?? todayStr();
+				if (!isValidDailyDate(d)) {
+					return {
+						content: [{ type: "text", text: `Invalid date format: ${d}. Use YYYY-MM-DD.` }],
+						isError: true,
+						details: { date: d },
+					};
+				}
 				const filePath = dailyPath(d);
 				const content = readFileSafe(filePath);
 				if (!content) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memory",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memory",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-memory",
-	"version": "0.3.6",
+	"version": "0.3.7",
 	"description": "Pi coding agent extension for memory with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "index.ts",
 	"type": "module",

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -185,6 +185,10 @@ describe("dailyPath", () => {
 		const result = dailyPath("2026-02-15");
 		expect(result).toContain(path.join("daily", "2026-02-15.md"));
 	});
+
+	test("rejects invalid date input", () => {
+		expect(() => dailyPath("../../outside")).toThrow("Invalid daily date");
+	});
 });
 
 describe("ensureDirs", () => {
@@ -819,6 +823,29 @@ describe("memory_read tool", () => {
 	test("read daily when file does not exist", async () => {
 		const result = await tools.memory_read.execute("c1", { target: "daily", date: "1999-01-01" }, null, null, {});
 		expect(result.content[0].text).toContain("No daily log for 1999-01-01");
+	});
+
+	test("read daily rejects path traversal in date", async () => {
+		const outsideBase = path.join(
+			os.tmpdir(),
+			`pi-memory-outside-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		);
+		const outsideFile = `${outsideBase}.md`;
+		fs.writeFileSync(outsideFile, "TOP SECRET", "utf-8");
+
+		try {
+			const result = await tools.memory_read.execute(
+				"c1",
+				{ target: "daily", date: `../../${path.basename(outsideBase)}` },
+				null,
+				null,
+				{},
+			);
+			expect(result.isError).toBe(true);
+			expect(result.content[0].text).toContain("Invalid date format");
+		} finally {
+			fs.rmSync(outsideFile, { force: true });
+		}
 	});
 
 	// -- list --


### PR DESCRIPTION
## Summary
- validate `memory_read` daily `date` input with strict `YYYY-MM-DD` format + calendar checks
- reject invalid dates early with a clear error response
- harden `dailyPath()` to throw on invalid date input
- add regression tests for invalid/traversal dates

## Why
`memory_read` previously accepted arbitrary `date` strings, which could escape the daily directory when joined into a path.

Closes #3

## Verification
- `npm test`
- `npm run lint`
- `npm run build`
- `bun test test/unit.test.ts -t "memory_read tool|dailyPath"`