### PR TITLE
fix: skip exit summary on /reload to prevent blocking

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -901,10 +901,17 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// --- session_shutdown: write exit summary + clean up timer ---
-	pi.on("session_shutdown", async (_event, ctx) => {
+	pi.on("session_shutdown", async (event, ctx) => {
 		if (terminalInputUnsubscribe) {
 			terminalInputUnsubscribe();
 			terminalInputUnsubscribe = null;
+		}
+
+		// /reload emits session_shutdown with reason "reload" before rebuilding the
+		// runtime. Generating an exit summary here would make every /reload block
+		// for several seconds on a live LLM call. Skip it — the session continues.
+		if (event.reason === "reload") {
+			return;
 		}
 
 		const reason = exitSummaryReason ?? "session-end";

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1046,6 +1046,61 @@ describe("lifecycle hooks", () => {
 		expect(content).toContain("API key resolution unavailable");
 	});
 
+	test("session_shutdown with reason=reload skips exit summary entirely", async () => {
+		// Regression test for: /reload blocks for several seconds because
+		// session_shutdown fires generateExitSummary() on every reload.
+		const ctx = createShutdownCtx({
+			branch: [
+				{
+					type: "message",
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "hi" }],
+						timestamp: Date.now(),
+					},
+				},
+			],
+			model: { provider: "openai", id: "gpt-4o-mini" },
+		});
+
+		await hooks.session_shutdown({ reason: "reload" }, ctx);
+
+		// No daily log file should have been created — summary was skipped.
+		expect(fs.existsSync(dailyPath(todayStr()))).toBe(false);
+	});
+
+	test("session_shutdown with reason=quit still writes exit summary", async () => {
+		// Ensure the reload-skip guard does not suppress real quit summaries.
+		const ctx = createShutdownCtx({
+			branch: [
+				{
+					type: "message",
+					message: {
+						role: "user",
+						content: [{ type: "text", text: "Remember: dark mode preferred" }],
+						timestamp: Date.now(),
+					},
+				},
+				{
+					type: "message",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "Noted." }],
+						timestamp: Date.now(),
+					},
+				},
+			],
+			model: { provider: "openai", id: "gpt-4o-mini" },
+			modelRegistry: {},
+		});
+
+		await hooks.session_shutdown({ reason: "quit" }, ctx);
+
+		// Fallback summary (no real API key) should still be written.
+		const content = fs.readFileSync(dailyPath(todayStr()), "utf-8");
+		expect(content).toContain("## Session Summary");
+	});
+
 	// -- session_before_compact --
 
 	test("session_before_compact appends handoff when scratchpad has open items", async () => {


### PR DESCRIPTION
Issue #7

## Description of changes

The `session_shutdown` handler calls `generateExitSummary()` unconditionally on every `/reload`. Since `/reload` emits `session_shutdown` with `reason: "reload"`, and the session continues afterward, no exit summary is needed — but the live LLM API call still fires, blocking `/reload` for several seconds whenever the session has messages.

The delay is invisible on a fresh empty session (`messages.length === 0` exits early), which is why it was easy to miss.

**Fix:** read `event.reason` in the handler and return early when it is `"reload"`. The `SessionShutdownEvent.reason` field is already part of pi's public extension API.

**Relationship to #5:** that issue was also in `generateExitSummary` — same path, different failure mode (throw vs. silent block).

## Changes

- `index.ts`: rename `_event` → `event`, add early return for `reason === "reload"`
- `test/unit.test.ts`: two regression tests added to the existing `lifecycle hooks` suite:
  - `session_shutdown with reason=reload skips exit summary entirely` — asserts no daily log file is written
  - `session_shutdown with reason=quit still writes exit summary` — asserts the guard does not suppress real quit summaries

## Validation

```
bun test test/unit.test.ts

105 pass
0 fail
197 expect() calls
Ran 105 tests across 1 file. [627.00ms]
```