### PR TITLE
fix: Windows compatibility — execFile wrapper + HOME fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ pi install ./pi-memory
 
 # Optional (enables `memory_search` + selective injection, requires Bun)
 command -v qmd >/dev/null 2>&1 || bun install -g https://github.com/tobi/qmd
+n> **Windows users**: After installing qmd, verify it works from a standard Command Prompt
+> (`cmd.exe /c qmd status`).  If you see "The system cannot find the path specified",
+> edit `%APPDATA%
+pmqmd.cmd` and replace `/bin/sh` with the full path to Git Bashs
+> `sh.exe` (typically `C:Program FilesGitusrbinsh.exe`).
 ```
 
 Or copy to your extensions directory:
@@ -195,6 +200,12 @@ pi install npm:pi-memory
 ```
 
 ## Changelog
+
+### 0.3.10
+
+- **Windows compatibility**: Fixed two issues that prevented `memory_search` from working on Windows:
+  - `execFile` cannot spawn `.cmd` files directly on Windows; qmd invocations are now wrapped with `cmd.exe /c`.
+  - `HOME` is often unset in Node.js on Windows; the memory directory now falls back to `USERPROFILE` so files land in the correct location instead of a literal `~` subdirectory.
 
 ### 0.3.6
 

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,20 @@ import { Type } from "@sinclair/typebox";
 // Paths (mutable for testing via _setBaseDir / _resetBaseDir)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MEMORY_DIR = process.env.PI_MEMORY_DIR ?? path.join(process.env.HOME ?? "~", ".pi", "agent", "memory");
+/**
+ * Resolve the memory directory cross-platform.
+ *
+ * PI_MEMORY_DIR, if set, is used as the full path.  Otherwise we join the
+ * user's home directory with `.pi/agent/memory`.  On Windows `HOME` is often
+ * unset; we fall back to `USERPROFILE` which is the canonical equivalent.
+ */
+function resolveMemoryDir(): string {
+	if (process.env.PI_MEMORY_DIR) return process.env.PI_MEMORY_DIR;
+	const home = process.env.HOME ?? process.env.USERPROFILE ?? "~";
+	return path.join(home, ".pi", "agent", "memory");
+}
+
+const DEFAULT_MEMORY_DIR = resolveMemoryDir();
 
 let MEMORY_DIR = DEFAULT_MEMORY_DIR;
 let MEMORY_FILE = path.join(MEMORY_DIR, "MEMORY.md");
@@ -593,7 +606,24 @@ export function buildMemoryContext(searchResults?: string): string {
 // ---------------------------------------------------------------------------
 
 type ExecFileFn = typeof execFile;
-let execFileFn: ExecFileFn = execFile;
+
+/**
+ * On Windows, Node's child_process.execFile cannot directly spawn .cmd / .bat
+ * files — it needs a shell.  We wrap qmd invocations so they go through
+ * `cmd.exe /c qmd …` which works reliably.
+ */
+function wrapExecFileForQmd(fn: typeof execFile): ExecFileFn {
+	if (process.platform !== "win32") return fn;
+	return (cmd, args, opts, cb) => {
+		if (cmd === "qmd") {
+			fn("cmd.exe", ["/c", cmd, ...args], opts ?? {}, cb);
+		} else {
+			fn(cmd, args, opts, cb);
+		}
+	};
+}
+
+let execFileFn: ExecFileFn = wrapExecFileForQmd(execFile);
 
 let qmdAvailable = false;
 let updateTimer: ReturnType<typeof setTimeout> | null = null;
@@ -607,7 +637,7 @@ export function _setExecFileForTest(fn: ExecFileFn) {
 
 /** Reset execFile implementation (for testing). */
 export function _resetExecFileForTest() {
-	execFileFn = execFile;
+	execFileFn = wrapExecFileForQmd(execFile);
 }
 
 /** Set qmd availability flag (for testing). */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-memory",
-	"version": "0.3.9",
+	"version": "0.3.10",
 	"description": "Pi coding agent extension for memory with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "index.ts",
 	"type": "module",


### PR DESCRIPTION

## Problem

memory_search and qmd integration are broken on Windows due to two issues:

### 1. execFile cannot spawn .cmd files
Node's child_process.execFile on Windows cannot directly spawn .cmd / .bat files — it needs a shell. The extension uses execFile('qmd', ...) everywhere, which fails with ENOENT or EINVAL on Windows.

Fix: Added wrapExecFileForQmd() that routes all qmd invocations through cmd.exe /c qmd ... on win32.

### 2. HOME is often unset in Node.js on Windows
The memory directory defaults to path.join(process.env.HOME ?? '~', '.pi', 'agent', 'memory'). On Windows, HOME is frequently undefined in Node.js processes, causing the literal string '~' to be used — creating a C:\Users\<name>\~\.pi\agent\memory\ directory.

Fix: Added resolveMemoryDir() that falls back to USERPROFILE (the canonical Windows home variable) before the ultimate '~' fallback.

## Changes
- wrapExecFileForQmd() — Windows execFile wrapper for qmd commands
- resolveMemoryDir() — cross-platform home directory resolution
- Updated _resetExecFileForTest() to preserve the wrapper
- README: Windows install notes + changelog entry
- Bump to 0.3.10

## Testing
Verified on Windows 10 with Git Bash, Node v22, and qmd 2.1.0. All four tools (memory_write, memory_read, scratchpad, memory_search) work correctly.