### PR TITLE
fix: use 'qmd collection list' for qmd detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -693,8 +693,10 @@ export async function setupQmdCollection(): Promise<boolean> {
 
 export function detectQmd(): Promise<boolean> {
 	return new Promise((resolve) => {
-		// qmd doesn't reliably support --version; use a fast command that exits 0 when available.
-		execFileFn("qmd", ["status"], { timeout: 5_000 }, (err) => {
+		// `qmd status` can trigger slow model/device probing on some systems (e.g. Vulkan fallback),
+		// which may exceed short startup timeouts and produce false negatives.
+		// `qmd collection list` is much lighter and still validates the binary is callable.
+		execFileFn("qmd", ["collection", "list"], { timeout: 15_000 }, (err) => {
 			resolve(!err);
 		});
 	});


### PR DESCRIPTION
## Summary

- Replace the `qmd status` probe in `detectQmd()` with `qmd collection list`, which doesn't trigger the slow model/device probe code path (e.g. Vulkan fallback) on some systems.
- Raise the timeout from 5s to 15s for headroom on slow systems.

On affected systems `qmd status` was taking 10–20s, blowing past the 5s timeout and producing a false negative. That caused the install banner to appear at every startup and `memory_search` to report qmd was unavailable — despite qmd being installed and healthy.

`checkCollection()` already uses `qmd collection list` in the same file, so the lighter probe is known-good.

Fixes #10

## Test plan

- [x] `bun test/e2e.ts` passes (6 passed, 5 skipped due to no qmd in env)
- [x] `biome check` passes
- [x] Manual verification on a system where `qmd status` is slow: banner no longer shown, `memory_search` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)