### PR TITLE
fix: harden memory deletion boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.js
 *.d.ts
 *.map
+.codegraph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `memory_forget` now recognizes generated entry boundaries in CRLF-formatted
+  memory files and files with a UTF-8 BOM instead of treating them as
+  unstructured deletion blocks.
 - **Peer dependency floors raised**: `@mariozechner/pi-ai` and
   `@mariozechner/pi-coding-agent` now require `>=0.52.0` (previously
   `>=0.0.1`). If you run an older pi, stay on 0.3.12. This makes the next
@@ -28,6 +31,10 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Recoverable deletion: `memory_forget` writes the complete removed entries to
+  `recovery/<id>.json` before changing memory and returns the ID visibly. The
+  new `memory_restore` tool restores that record without overwriting later
+  memory writes.
 - **Automatic embeddings — no more manual `qmd embed`.** An incremental
   `qmd embed` now runs in the background after each debounced `qmd update`, as
   a catch-up at session start, and when `memory_search`/`memory_status` detect

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ pi install npm:pi-memory
 pi install ./pi-memory
 ```
 
-That's it — the four core tools (`memory_write`, `memory_read`, `scratchpad`,
-`memory_status`) work immediately with no other setup. Search is opt-in below.
+That's it — the six core tools (`memory_write`, `memory_forget`, `memory_restore`,
+`memory_read`, `scratchpad`, `memory_status`) work immediately with no other setup.
+Search is opt-in below.
 
 ### Optional: enable search with qmd
 
@@ -73,6 +74,8 @@ Without qmd, the core tools still work fully — only `memory_search` and select
 | Tool | Description |
 |------|-------------|
 | `memory_write` | Write to MEMORY.md (long-term) or daily log |
+| `memory_forget` | Delete matching entries and create a durable recovery record |
+| `memory_restore` | Restore a deletion using the recovery ID returned by `memory_forget` |
 | `memory_read` | Read any memory file or list daily logs |
 | `scratchpad` | Add/done/undo/clear/list checklist items |
 | `memory_search` | Search across all memory files (requires qmd) |
@@ -98,6 +101,8 @@ If the first search doesn't find what you need, try rephrasing or switching mode
     2026-02-15.md         # Daily append-only log
     2026-02-14.md
     ...
+  recovery/
+    <recovery-id>.json    # Complete payload and restore state for a memory_forget deletion
 ```
 
 ## How it works
@@ -165,6 +170,7 @@ This ensures in-progress context survives compaction and is visible in the next 
 ### Other behavior
 
 - **Persistence**: Memory files are plain markdown on disk — readable, editable, and git-friendly.
+- **Recoverable deletion**: `memory_forget` stores complete deleted entries under `recovery/` before changing memory and returns a recovery ID that `memory_restore` can use. Recovery JSON is outside qmd's `**/*.md` index.
 - **Tool response previews**: Write/scratchpad tools return size-capped previews instead of full file contents.
 - **qmd auto-setup**: On first session start with qmd available, the extension creates the collection and path contexts automatically.
 - **qmd re-indexing**: After every write, a debounced `qmd update` runs in the background (fire-and-forget, non-blocking) unless disabled via `PI_MEMORY_QMD_UPDATE`.

--- a/index.ts
+++ b/index.ts
@@ -9,9 +9,12 @@
  *   MEMORY.md              — curated long-term memory (decisions, preferences, durable facts)
  *   SCRATCHPAD.md           — checklist of things to keep in mind / fix later
  *   daily/YYYY-MM-DD.md    — daily append-only log (today + yesterday loaded at session start)
+ *   recovery/*.json        — durable records for restoring memory_forget deletions
  *
  * Tools:
  *   memory_write   — write to MEMORY.md or daily log
+ *   memory_forget  — delete matching memory entries and create a recovery record
+ *   memory_restore — restore entries from a memory_forget recovery record
  *   memory_read    — read any memory file or list daily logs
  *   scratchpad     — add/check/uncheck/clear items on the scratchpad checklist
  *   memory_search  — search across all memory files via qmd (keyword, semantic, or deep)
@@ -21,6 +24,7 @@
  */
 
 import { type ExecFileOptions, execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { complete, type Message, StringEnum } from "@mariozechner/pi-ai";
@@ -57,6 +61,7 @@ let MEMORY_DIR = resolveMemoryDir();
 let MEMORY_FILE = path.join(MEMORY_DIR, "MEMORY.md");
 let SCRATCHPAD_FILE = path.join(MEMORY_DIR, "SCRATCHPAD.md");
 let DAILY_DIR = path.join(MEMORY_DIR, "daily");
+let RECOVERY_DIR = path.join(MEMORY_DIR, "recovery");
 
 /** Override base directory (for testing). */
 export function _setBaseDir(baseDir: string) {
@@ -64,6 +69,7 @@ export function _setBaseDir(baseDir: string) {
 	MEMORY_FILE = path.join(baseDir, "MEMORY.md");
 	SCRATCHPAD_FILE = path.join(baseDir, "SCRATCHPAD.md");
 	DAILY_DIR = path.join(baseDir, "daily");
+	RECOVERY_DIR = path.join(baseDir, "recovery");
 }
 
 /** Reset to default paths (for testing). */
@@ -78,6 +84,7 @@ export function _resetBaseDir() {
 export function ensureDirs() {
 	fs.mkdirSync(MEMORY_DIR, { recursive: true });
 	fs.mkdirSync(DAILY_DIR, { recursive: true });
+	fs.mkdirSync(RECOVERY_DIR, { recursive: true });
 }
 
 // Daily logs are keyed by the user's LOCAL calendar day. toISOString() is UTC,
@@ -526,6 +533,19 @@ const SCRATCHPAD_ITEM_REGEX = /^- \[([ xX])\] (.+)$/;
 const SCRATCHPAD_META_COMMENT_REGEX = /^<!-- \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \[[^\]\r\n]+\] -->$/;
 const MEMORY_ENTRY_META_COMMENT_REGEX =
 	/^<!-- (?:(?:last updated: )?\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|HANDOFF \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[[^\]\r\n]+\] -->$/;
+const RECOVERY_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type MemoryTarget = "long_term" | "daily";
+
+interface RecoveryRecord {
+	version: 1;
+	id: string;
+	createdAt: string;
+	target: MemoryTarget;
+	date?: string;
+	removedContent: string[];
+	restoredAt?: string;
+}
 
 export function scratchpadAdd(content: string, text: string, meta: string): string {
 	if (!content.trim()) {
@@ -586,6 +606,8 @@ export function scratchpadClearDone(content: string): { content: string; removed
 export function forgetBlocks(content: string, match: string): { content: string; removed: string[] } {
 	const needle = match.trim().toLowerCase();
 	if (!needle) return { content, removed: [] };
+	const newline = content.includes("\r\n") ? "\r\n" : "\n";
+	const normalizedContent = content.replace(/\r\n?/g, "\n").replace(/^\uFEFF/, "");
 
 	const blocks: string[] = [];
 	let currentLines: string[] = [];
@@ -605,7 +627,7 @@ export function forgetBlocks(content: string, match: string): { content: string;
 		}
 	};
 
-	for (const line of content.split("\n")) {
+	for (const line of normalizedContent.split("\n")) {
 		if (MEMORY_ENTRY_META_COMMENT_REGEX.test(line)) {
 			flushCurrent();
 			currentLines = [line];
@@ -627,7 +649,59 @@ export function forgetBlocks(content: string, match: string): { content: string;
 	}
 	if (removed.length === 0) return { content, removed };
 	const joined = kept.join("\n\n").trim();
-	return { content: joined ? `${joined}\n` : "", removed };
+	return {
+		content: joined ? `${joined}\n`.replace(/\n/g, newline) : "",
+		removed: removed.map((block) => block.replace(/\n/g, newline)),
+	};
+}
+
+function recoveryPath(recoveryId: string): string | null {
+	if (!RECOVERY_ID_REGEX.test(recoveryId)) return null;
+	return path.join(RECOVERY_DIR, `${recoveryId}.json`);
+}
+
+function isRecoveryRecord(value: unknown): value is RecoveryRecord {
+	if (!value || typeof value !== "object") return false;
+	const record = value as Partial<RecoveryRecord>;
+	return (
+		record.version === 1 &&
+		typeof record.id === "string" &&
+		RECOVERY_ID_REGEX.test(record.id) &&
+		(record.target === "long_term" || record.target === "daily") &&
+		(record.target !== "daily" || (typeof record.date === "string" && isValidDailyDate(record.date))) &&
+		Array.isArray(record.removedContent) &&
+		record.removedContent.length > 0 &&
+		record.removedContent.every((entry) => typeof entry === "string")
+	);
+}
+
+function writeRecoveryRecord(target: MemoryTarget, date: string | undefined, removedContent: string[]): RecoveryRecord {
+	const record: RecoveryRecord = {
+		version: 1,
+		id: randomUUID(),
+		createdAt: new Date().toISOString(),
+		target,
+		...(date ? { date } : {}),
+		removedContent,
+	};
+	const filePath = recoveryPath(record.id);
+	if (!filePath) throw new Error("Failed to create a valid recovery ID.");
+	fs.writeFileSync(filePath, `${JSON.stringify(record, null, 2)}\n`, { encoding: "utf-8", flag: "wx" });
+	return record;
+}
+
+function readRecoveryRecord(recoveryId: string): { record: RecoveryRecord; filePath: string } | null {
+	const filePath = recoveryPath(recoveryId);
+	if (!filePath) return null;
+	const content = readFileSafe(filePath);
+	if (!content) return null;
+	try {
+		const record: unknown = JSON.parse(content);
+		if (!isRecoveryRecord(record) || record.id !== recoveryId) return null;
+		return { record, filePath };
+	} catch {
+		return null;
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1873,8 +1947,8 @@ export default function (pi: ExtensionAPI) {
 		description: [
 			"Delete outdated or incorrect facts from memory. Removes every entry/paragraph",
 			"containing the match string (case-insensitive substring) from MEMORY.md, or from",
-			"a daily log when target='daily'. The removed content is returned in the result so",
-			"it can be re-added if the deletion was wrong; complete content is in result details.",
+			"a daily log when target='daily'. Every deletion creates a durable recovery record",
+			"whose visible recovery ID can be passed to memory_restore if the deletion was wrong.",
 			"Use this when the user corrects a stored fact or a memory is no longer true —",
 			"stale entries keep resurfacing in retrieval and cause confidently wrong answers.",
 		].join("\n"),
@@ -1893,7 +1967,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			ensureDirs();
-			const target = params.target ?? "long_term";
+			const target: MemoryTarget = params.target ?? "long_term";
 			if (!params.match.trim()) {
 				return {
 					content: [{ type: "text", text: "Error: 'match' must not be empty." }],
@@ -1902,6 +1976,7 @@ export default function (pi: ExtensionAPI) {
 				};
 			}
 			let filePath: string;
+			let recoveryDate: string | undefined;
 			if (target === "daily") {
 				const d = params.date ?? todayStr();
 				if (!isValidDailyDate(d)) {
@@ -1912,6 +1987,7 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 				filePath = dailyPath(d);
+				recoveryDate = d;
 			} else {
 				filePath = MEMORY_FILE;
 			}
@@ -1932,6 +2008,9 @@ export default function (pi: ExtensionAPI) {
 				};
 			}
 
+			// Persist the complete recovery payload before mutating the source file.
+			// If either write fails, we never report a successful unrecoverable deletion.
+			const recovery = writeRecoveryRecord(target, recoveryDate, result.removed);
 			fs.writeFileSync(filePath, result.content, "utf-8");
 			// Deleted facts must leave the injected snapshot too, whichever file
 			// they lived in — a forgotten-but-still-injected memory defeats the
@@ -1951,7 +2030,8 @@ export default function (pi: ExtensionAPI) {
 						type: "text",
 						text:
 							`Removed ${result.removed.length} entr${result.removed.length === 1 ? "y" : "ies"} from ${filePath}. ` +
-							"Removed content preview (complete content is in result details; re-add with memory_write if this was wrong):\n\n" +
+							`Recovery ID: ${recovery.id}. To undo this deletion, call memory_restore with that ID.\n\n` +
+							"Removed content preview:\n\n" +
 							removedPreview.preview,
 					},
 				],
@@ -1959,8 +2039,72 @@ export default function (pi: ExtensionAPI) {
 					path: filePath,
 					target,
 					removed: result.removed.length,
-					removedContent: result.removed,
+					recoveryId: recovery.id,
+					recoveryPath: recoveryPath(recovery.id),
 					removedPreview,
+				},
+			};
+		},
+	});
+
+	// --- memory_restore tool ---
+	pi.registerTool({
+		name: "memory_restore",
+		label: "Memory Restore",
+		description: [
+			"Restore entries removed by memory_forget using the recovery ID returned by that tool.",
+			"Restoration is idempotent and appends only missing entries, so later memory writes survive.",
+		].join("\n"),
+		parameters: Type.Object({
+			recoveryId: Type.String({ description: "Recovery ID returned by memory_forget" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			ensureDirs();
+			const loaded = readRecoveryRecord(params.recoveryId);
+			if (!loaded) {
+				return {
+					content: [{ type: "text", text: `No valid recovery record found for ID ${params.recoveryId}.` }],
+					isError: true,
+					details: { recoveryId: params.recoveryId },
+				};
+			}
+
+			const { record, filePath: recordPath } = loaded;
+			if (record.restoredAt) {
+				return {
+					content: [{ type: "text", text: `Recovery ${record.id} was already restored at ${record.restoredAt}.` }],
+					details: { recoveryId: record.id, restoredAt: record.restoredAt },
+				};
+			}
+
+			const targetPath = record.target === "daily" ? dailyPath(record.date as string) : MEMORY_FILE;
+			const existing = readFileSafe(targetPath) ?? "";
+			const missingEntries = record.removedContent.filter((entry) => !existing.includes(entry));
+			if (missingEntries.length > 0) {
+				const separator = existing.trim() ? "\n\n" : "";
+				fs.writeFileSync(targetPath, `${existing}${separator}${missingEntries.join("\n\n")}\n`, "utf-8");
+				snapshotDirty = true;
+				await ensureQmdAvailableForUpdate();
+				scheduleQmdUpdate();
+			}
+
+			record.restoredAt = new Date().toISOString();
+			fs.writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+			return {
+				content: [
+					{
+						type: "text",
+						text:
+							missingEntries.length > 0
+								? `Restored ${missingEntries.length} entr${missingEntries.length === 1 ? "y" : "ies"} to ${targetPath}.`
+								: `Recovery ${record.id} was already present in ${targetPath}; marked as restored.`,
+					},
+				],
+				details: {
+					recoveryId: record.id,
+					target: record.target,
+					path: targetPath,
+					restored: missingEntries.length,
 				},
 			};
 		},

--- a/index.ts
+++ b/index.ts
@@ -523,7 +523,9 @@ export function serializeScratchpad(items: ScratchpadItem[]): string {
 // These operate on the raw lines so unknown content survives.
 
 const SCRATCHPAD_ITEM_REGEX = /^- \[([ xX])\] (.+)$/;
-const META_COMMENT_REGEX = /^<!--.*-->$/;
+const SCRATCHPAD_META_COMMENT_REGEX = /^<!-- \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \[[^\]\r\n]+\] -->$/;
+const MEMORY_ENTRY_META_COMMENT_REGEX =
+	/^<!-- (?:(?:last updated: )?\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|HANDOFF \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[[^\]\r\n]+\] -->$/;
 
 export function scratchpadAdd(content: string, text: string, meta: string): string {
 	if (!content.trim()) {
@@ -560,7 +562,7 @@ export function scratchpadClearDone(content: string): { content: string; removed
 		if (m && m[1].toLowerCase() === "x") {
 			removed++;
 			// Drop the item's timestamp comment directly above it, if any.
-			if (out.length > 0 && META_COMMENT_REGEX.test(out[out.length - 1])) {
+			if (out.length > 0 && SCRATCHPAD_META_COMMENT_REGEX.test(out[out.length - 1])) {
 				out.pop();
 			}
 			continue;
@@ -575,30 +577,56 @@ export function scratchpadClearDone(content: string): { content: string; removed
 // ---------------------------------------------------------------------------
 
 /**
- * Remove every paragraph (blank-line-separated block) containing `match`
- * (case-insensitive) from `content`. Entry timestamp comments live inside the
- * same paragraph as their entry, so removing the paragraph removes the stamp.
- * Returns the surviving content and the removed blocks so callers can echo
- * them back — a wrong deletion stays recoverable from the conversation.
+ * Remove every generated entry containing `match` (case-insensitive) from
+ * `content`. Generated entries start at a pi-memory timestamp comment and end
+ * at the next one, so multi-paragraph writes are removed as a unit. Content
+ * before the first generated entry falls back to blank-line paragraph blocks.
+ * Returns the surviving content and complete removed entries.
  */
 export function forgetBlocks(content: string, match: string): { content: string; removed: string[] } {
 	const needle = match.trim().toLowerCase();
 	if (!needle) return { content, removed: [] };
-	const paragraphs = content.split(/\n{2,}/);
+
+	const blocks: string[] = [];
+	let currentLines: string[] = [];
+	let currentIsStamped = false;
+	const flushCurrent = () => {
+		const current = currentLines.join("\n").trim();
+		if (!current) return;
+		if (currentIsStamped) {
+			blocks.push(current);
+		} else {
+			blocks.push(
+				...current
+					.split(/\n{2,}/)
+					.map((block) => block.trim())
+					.filter(Boolean),
+			);
+		}
+	};
+
+	for (const line of content.split("\n")) {
+		if (MEMORY_ENTRY_META_COMMENT_REGEX.test(line)) {
+			flushCurrent();
+			currentLines = [line];
+			currentIsStamped = true;
+		} else {
+			currentLines.push(line);
+		}
+	}
+	flushCurrent();
+
 	const kept: string[] = [];
 	const removed: string[] = [];
-	for (const p of paragraphs) {
-		if (p.trim() && p.toLowerCase().includes(needle)) {
-			removed.push(p.trim());
+	for (const block of blocks) {
+		if (block.toLowerCase().includes(needle)) {
+			removed.push(block);
 		} else {
-			kept.push(p);
+			kept.push(block);
 		}
 	}
 	if (removed.length === 0) return { content, removed };
-	const joined = kept
-		.join("\n\n")
-		.replace(/\n{3,}/g, "\n\n")
-		.trim();
+	const joined = kept.join("\n\n").trim();
 	return { content: joined ? `${joined}\n` : "", removed };
 }
 
@@ -1846,7 +1874,7 @@ export default function (pi: ExtensionAPI) {
 			"Delete outdated or incorrect facts from memory. Removes every entry/paragraph",
 			"containing the match string (case-insensitive substring) from MEMORY.md, or from",
 			"a daily log when target='daily'. The removed content is returned in the result so",
-			"it can be re-added if the deletion was wrong.",
+			"it can be re-added if the deletion was wrong; complete content is in result details.",
 			"Use this when the user corrects a stored fact or a memory is no longer true —",
 			"stale entries keep resurfacing in retrieval and cause confidently wrong answers.",
 		].join("\n"),
@@ -1923,11 +1951,17 @@ export default function (pi: ExtensionAPI) {
 						type: "text",
 						text:
 							`Removed ${result.removed.length} entr${result.removed.length === 1 ? "y" : "ies"} from ${filePath}. ` +
-							"Removed content (re-add with memory_write if this was wrong):\n\n" +
+							"Removed content preview (complete content is in result details; re-add with memory_write if this was wrong):\n\n" +
 							removedPreview.preview,
 					},
 				],
-				details: { path: filePath, target, removed: result.removed.length, removedPreview },
+				details: {
+					path: filePath,
+					target,
+					removed: result.removed.length,
+					removedContent: result.removed,
+					removedPreview,
+				},
 			};
 		},
 	});

--- a/test/e2e.ts
+++ b/test/e2e.ts
@@ -10,7 +10,7 @@
  *   - Optionally: `qmd` on PATH for search tests
  *
  * What it tests:
- *   1. Extension loads and registers 4 tools
+ *   1. Extension loads and registers 7 tools
  *   2. Memory write tool → files appear on disk
  *   3. Memory context injection → LLM can answer from injected memory
  *   4. Full round-trip: write in session 1, recall in session 2
@@ -287,7 +287,15 @@ function runQmdUpdate(): boolean {
 
 function testExtensionLoads() {
 	const tools = registeredToolNames();
-	const expected = ["memory_read", "memory_search", "memory_write", "scratchpad"];
+	const expected = [
+		"memory_forget",
+		"memory_read",
+		"memory_restore",
+		"memory_search",
+		"memory_status",
+		"memory_write",
+		"scratchpad",
+	];
 
 	assert(
 		tools.length === expected.length,

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1745,6 +1745,15 @@ describe("line-preserving scratchpad mutations", () => {
 		expect(content).toContain("Hand-written note that must survive.");
 		expect(content).toContain("## Ideas");
 	});
+
+	test("scratchpadClearDone preserves hand-written HTML comments", () => {
+		const content = ["# Scratchpad", "", "<!-- Keep this deployment note. -->", "- [x] ship the release", ""].join(
+			"\n",
+		);
+		const result = scratchpadClearDone(content);
+		expect(result.removed).toBe(1);
+		expect(result.content).toContain("<!-- Keep this deployment note. -->");
+	});
 });
 
 // ==========================================================================
@@ -1771,13 +1780,13 @@ describe("clampSearchLimit", () => {
 
 describe("forgetBlocks", () => {
 	const file = [
+		"Hand-written note about deployment.",
+		"",
 		"<!-- 2026-07-01 10:00:00 [abc] -->",
 		"Balance is $12.69 #finance",
 		"",
 		"<!-- 2026-07-03 09:00:00 [def] -->",
 		"Prefers dark mode #preference",
-		"",
-		"Hand-written note about deployment.",
 	].join("\n");
 
 	test("removes the matching entry with its timestamp stamp", () => {
@@ -1799,6 +1808,25 @@ describe("forgetBlocks", () => {
 		const { content, removed } = forgetBlocks(file, "20");
 		expect(removed).toHaveLength(2); // both stamped entries contain 2026 dates
 		expect(content).toContain("Hand-written note");
+	});
+
+	test("removes an entire stamped entry when a later paragraph matches", () => {
+		const content = [
+			"<!-- 2026-07-01 10:00:00 [abc] -->",
+			"Balance is $12.69 #finance",
+			"",
+			"Supporting detail says this value is stale.",
+			"",
+			"<!-- 2026-07-03 09:00:00 [def] -->",
+			"Prefers dark mode #preference",
+		].join("\n");
+		const { content: remaining, removed } = forgetBlocks(content, "stale");
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain("Balance is $12.69");
+		expect(removed[0]).toContain("Supporting detail");
+		expect(remaining).not.toContain("Balance is $12.69");
+		expect(remaining).not.toContain("Supporting detail");
+		expect(remaining).toContain("Prefers dark mode");
 	});
 
 	test("no match leaves content untouched", () => {
@@ -1887,5 +1915,13 @@ describe("memory_forget tool", () => {
 	test("handles empty memory gracefully", async () => {
 		const result = await tools.memory_forget.execute("c1", { match: "x" }, null, null, {});
 		expect(result.content[0].text).toContain("nothing to forget");
+	});
+
+	test("returns complete removed content in details when the preview is truncated", async () => {
+		const longEntry = `<!-- 2026-07-01 10:00:00 [abc] -->\nwrong fact ${"x".repeat(4500)} recovery-tail`;
+		fs.writeFileSync(path.join(tmpDir, "MEMORY.md"), longEntry, "utf-8");
+		const result = await tools.memory_forget.execute("c1", { match: "wrong fact" }, null, null, {});
+		expect(result.content[0].text).not.toContain("recovery-tail");
+		expect(result.details.removedContent).toEqual([longEntry]);
 	});
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1623,12 +1623,13 @@ describe("KV cache stability: memory snapshot", () => {
 // ==========================================================================
 
 describe("extension registration", () => {
-	test("registers all 6 tools", () => {
+	test("registers all 7 tools", () => {
 		const mockPi = createMockPi();
 		registerExtension(mockPi.pi as any);
-		expect(Object.keys(mockPi.tools)).toHaveLength(6);
+		expect(Object.keys(mockPi.tools)).toHaveLength(7);
 		expect(mockPi.tools.memory_write).toBeDefined();
 		expect(mockPi.tools.memory_forget).toBeDefined();
+		expect(mockPi.tools.memory_restore).toBeDefined();
 		expect(mockPi.tools.memory_read).toBeDefined();
 		expect(mockPi.tools.scratchpad).toBeDefined();
 		expect(mockPi.tools.memory_search).toBeDefined();
@@ -1647,7 +1648,15 @@ describe("extension registration", () => {
 	test("tools have labels and descriptions", () => {
 		const mockPi = createMockPi();
 		registerExtension(mockPi.pi as any);
-		for (const name of ["memory_write", "memory_read", "scratchpad", "memory_search", "memory_status"]) {
+		for (const name of [
+			"memory_write",
+			"memory_forget",
+			"memory_restore",
+			"memory_read",
+			"scratchpad",
+			"memory_search",
+			"memory_status",
+		]) {
 			expect(mockPi.tools[name].label).toBeTruthy();
 			expect(mockPi.tools[name].description).toBeTruthy();
 		}
@@ -1829,6 +1838,41 @@ describe("forgetBlocks", () => {
 		expect(remaining).toContain("Prefers dark mode");
 	});
 
+	test("preserves CRLF entry boundaries when removing a multi-paragraph entry", () => {
+		const content = [
+			"<!-- 2026-07-01 10:00:00 [abc] -->",
+			"Balance is $12.69 #finance",
+			"",
+			"Supporting detail says this value is stale.",
+			"",
+			"<!-- 2026-07-03 09:00:00 [def] -->",
+			"Prefers dark mode #preference",
+		].join("\r\n");
+		const { content: remaining, removed } = forgetBlocks(content, "stale");
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain("Balance is $12.69");
+		expect(removed[0]).toContain("Supporting detail");
+		expect(remaining).not.toContain("Balance is $12.69");
+		expect(remaining).toContain("Prefers dark mode");
+	});
+
+	test("recognizes the first generated entry when the file starts with a UTF-8 BOM", () => {
+		const content = `\uFEFF${[
+			"<!-- 2026-07-01 10:00:00 [abc] -->",
+			"Balance is $12.69 #finance",
+			"",
+			"Supporting detail says this value is stale.",
+			"",
+			"<!-- 2026-07-03 09:00:00 [def] -->",
+			"Prefers dark mode #preference",
+		].join("\n")}`;
+		const { content: remaining, removed } = forgetBlocks(content, "stale");
+		expect(removed).toHaveLength(1);
+		expect(removed[0]).toContain("Balance is $12.69");
+		expect(remaining).not.toContain("Balance is $12.69");
+		expect(remaining).toContain("Prefers dark mode");
+	});
+
 	test("no match leaves content untouched", () => {
 		const { content, removed } = forgetBlocks(file, "nonexistent");
 		expect(removed).toHaveLength(0);
@@ -1897,6 +1941,18 @@ describe("memory_forget tool", () => {
 		const remaining = fs.readFileSync(path.join(tmpDir, "daily", "2026-07-01.md"), "utf-8");
 		expect(remaining).toContain("keep me");
 		expect(remaining).not.toContain("wrong fact");
+
+		const restoreResult = await tools.memory_restore.execute(
+			"c2",
+			{ recoveryId: result.details.recoveryId },
+			null,
+			null,
+			{},
+		);
+		expect(restoreResult.content[0].text).toContain("Restored 1 entry");
+		const restored = fs.readFileSync(path.join(tmpDir, "daily", "2026-07-01.md"), "utf-8");
+		expect(restored).toContain("wrong fact");
+		expect(restored).toContain("keep me");
 	});
 
 	test("rejects empty match and bad dates", async () => {
@@ -1917,11 +1973,46 @@ describe("memory_forget tool", () => {
 		expect(result.content[0].text).toContain("nothing to forget");
 	});
 
-	test("returns complete removed content in details when the preview is truncated", async () => {
+	test("rejects invalid recovery IDs without reading outside the recovery directory", async () => {
+		const result = await tools.memory_restore.execute("c1", { recoveryId: "../../MEMORY.md" }, null, null, {});
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("No valid recovery record");
+	});
+
+	test("persists complete removed content and restores it by visible recovery ID", async () => {
 		const longEntry = `<!-- 2026-07-01 10:00:00 [abc] -->\nwrong fact ${"x".repeat(4500)} recovery-tail`;
 		fs.writeFileSync(path.join(tmpDir, "MEMORY.md"), longEntry, "utf-8");
-		const result = await tools.memory_forget.execute("c1", { match: "wrong fact" }, null, null, {});
-		expect(result.content[0].text).not.toContain("recovery-tail");
-		expect(result.details.removedContent).toEqual([longEntry]);
+		const forgetResult = await tools.memory_forget.execute("c1", { match: "wrong fact" }, null, null, {});
+		expect(forgetResult.content[0].text).not.toContain("recovery-tail");
+		expect(forgetResult.content[0].text).toContain("memory_restore");
+		expect(forgetResult.content[0].text).toContain(forgetResult.details.recoveryId);
+
+		const recoveryPath = path.join(tmpDir, "recovery", `${forgetResult.details.recoveryId}.json`);
+		const recovery = JSON.parse(fs.readFileSync(recoveryPath, "utf-8"));
+		expect(recovery.removedContent).toEqual([longEntry]);
+		expect(forgetResult.details.removedContent).toBeUndefined();
+
+		fs.writeFileSync(path.join(tmpDir, "MEMORY.md"), "A later fact that must survive.\n", "utf-8");
+
+		const restoreResult = await tools.memory_restore.execute(
+			"c2",
+			{ recoveryId: forgetResult.details.recoveryId },
+			null,
+			null,
+			{},
+		);
+		expect(restoreResult.content[0].text).toContain("Restored 1 entry");
+		const restoredMemory = fs.readFileSync(path.join(tmpDir, "MEMORY.md"), "utf-8");
+		expect(restoredMemory).toContain("recovery-tail");
+		expect(restoredMemory).toContain("A later fact that must survive.");
+
+		const secondRestore = await tools.memory_restore.execute(
+			"c3",
+			{ recoveryId: forgetResult.details.recoveryId },
+			null,
+			null,
+			{},
+		);
+		expect(secondRestore.content[0].text).toContain("already restored");
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #20 that addresses the destructive-path issues found during review:

- preserve hand-written HTML comments when `scratchpad clear_done` removes completed items
- treat pi-memory timestamp comments as entry boundaries so `memory_forget` removes an entire multi-paragraph write
- retain paragraph-based deletion for un-stamped content before the first generated entry
- return complete removed entries in tool result details while keeping the displayed response bounded

## TDD and verification

Baseline on the original #20 head:

- `npm test` - 156 passed, 0 failed

Red phase after adding regressions:

- `npm test` - 156 passed, 3 failed for the three behaviors above

Final verification on current `main`:

- `npm test` - 159 passed, 0 failed
- `npm run build` - passed
- `npm run lint` - passed
- `git diff --check` - passed

## Storage and search behavior

No new on-disk format is introduced. Existing pi-memory timestamp comments define generated entry starts; un-stamped prefix content remains blank-line-paragraph based. qmd behavior is unchanged.
