### PR TITLE
feat: make exit summary configurable (opt-out + model override)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `PI_MEMORY_EXIT_SUMMARY=0` (aliases: `off`/`false`/`no`) disables the exit
+  summary on real quit (Ctrl+D, `/quit`, session end). With summaries disabled,
+  quitting performs no LLM call and no `qmd update`, so it is instant.
+  Lifecycle-transition skips are unchanged. (#26)
+- `PI_MEMORY_EXIT_SUMMARY_MODEL=provider/model-id` overrides the model used to
+  write exit summaries (default: the session's active model), e.g. to route
+  summaries to a cheaper/faster model. Unresolvable specs fall back to the
+  session model with a warning. (#26)
+
 ### Changed
 
 - Reduced pull-request CI duplication and setup overhead by consolidating the

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ This ensures in-progress context survives compaction and is visible in the next 
 | `PI_MEMORY_QMD_SEARCH_TIMEOUT_MS` | positive integer (milliseconds) | `60000` | Sets the timeout for explicit `memory_search` qmd queries |
 | `PI_MEMORY_NO_SEARCH` | `1` | unset | Disable selective injection in `per-turn` mode (no effect in `stable` mode) |
 | `PI_MEMORY_SUMMARIZE_TRANSITIONS` | `1`, `true`, `yes`, `on` | unset | Also write exit summaries during lifecycle transitions (`/reload`, `/new`, `/resume`, `/fork`). By default these transitions skip summaries for speed. |
+| `PI_MEMORY_EXIT_SUMMARY` | `0`, `off`, `false`, `no` to disable | unset (enabled) | Disable the exit summary on real quit (Ctrl+D, `/quit`, session end). Quitting then does no LLM call and no `qmd update`, so it is instant; explicit `memory_write` during sessions is unaffected. |
+| `PI_MEMORY_EXIT_SUMMARY_MODEL` | `provider/model-id` | unset (session model) | Model used to write the exit summary, e.g. a cheaper/faster one. Unresolvable specs fall back to the session model with a warning. |
 
 ## Troubleshooting
 

--- a/index.ts
+++ b/index.ts
@@ -367,23 +367,53 @@ function getSessionBranch(ctx: ExtensionContext): SessionEntry[] | null {
 	return sessionManager.getBranch();
 }
 
-async function resolveExitSummaryApiKey(ctx: ExtensionContext): Promise<string | undefined> {
-	if (!ctx.model) return undefined;
-
+async function resolveExitSummaryApiKey(
+	ctx: ExtensionContext,
+	model: NonNullable<ExtensionContext["model"]>,
+): Promise<string | undefined> {
 	const modelRegistry = ctx.modelRegistry as ExtensionContext["modelRegistry"] & {
 		getApiKey?: (model: NonNullable<ExtensionContext["model"]>) => Promise<string | undefined>;
 		getApiKeyForProvider?: (provider: string) => Promise<string | undefined>;
 	};
 
 	if (typeof modelRegistry?.getApiKey === "function") {
-		return modelRegistry.getApiKey(ctx.model);
+		return modelRegistry.getApiKey(model);
 	}
 
 	if (typeof modelRegistry?.getApiKeyForProvider === "function") {
-		return modelRegistry.getApiKeyForProvider(ctx.model.provider);
+		return modelRegistry.getApiKeyForProvider(model.provider);
 	}
 
 	return undefined;
+}
+
+/**
+ * Model used for exit summaries. Defaults to the session's active model;
+ * PI_MEMORY_EXIT_SUMMARY_MODEL="provider/model-id" overrides it (e.g. to a
+ * cheaper/faster model). Unresolvable specs fall back to the session model.
+ */
+function resolveExitSummaryModel(ctx: ExtensionContext): ExtensionContext["model"] {
+	const spec = (process.env.PI_MEMORY_EXIT_SUMMARY_MODEL ?? "").trim();
+	if (!spec) return ctx.model;
+
+	const slash = spec.indexOf("/");
+	const modelRegistry = ctx.modelRegistry as ExtensionContext["modelRegistry"] & {
+		find?: (provider: string, modelId: string) => ExtensionContext["model"];
+	};
+	const found = slash > 0 ? modelRegistry?.find?.(spec.slice(0, slash), spec.slice(slash + 1)) : undefined;
+	if (found) return found;
+
+	if (ctx.hasUI) {
+		try {
+			ctx.ui.notify(
+				`pi-memory: PI_MEMORY_EXIT_SUMMARY_MODEL "${spec}" not resolved; using session model`,
+				"warning",
+			);
+		} catch {
+			/* UI may already be tearing down during shutdown */
+		}
+	}
+	return ctx.model;
 }
 
 async function generateExitSummary(ctx: ExtensionContext): Promise<ExitSummaryResult> {
@@ -404,15 +434,16 @@ async function generateExitSummary(ctx: ExtensionContext): Promise<ExitSummaryRe
 		return { summary: null, hasMessages: false };
 	}
 
-	if (!ctx.model) {
+	const model = resolveExitSummaryModel(ctx);
+	if (!model) {
 		return { summary: null, error: "No active model", hasMessages: true };
 	}
 
-	const apiKey = await resolveExitSummaryApiKey(ctx);
+	const apiKey = await resolveExitSummaryApiKey(ctx, model);
 	if (!apiKey) {
 		return {
 			summary: null,
-			error: `API key resolution unavailable for ${ctx.model.provider}/${ctx.model.id}`,
+			error: `API key resolution unavailable for ${model.provider}/${model.id}`,
 			hasMessages: true,
 		};
 	}
@@ -434,7 +465,7 @@ async function generateExitSummary(ctx: ExtensionContext): Promise<ExitSummaryRe
 
 	try {
 		const response = await complete(
-			ctx.model,
+			model,
 			{ systemPrompt: EXIT_SUMMARY_SYSTEM_PROMPT, messages: summaryMessages },
 			{ apiKey, reasoningEffort: "low" },
 		);
@@ -466,6 +497,15 @@ function getQmdUpdateMode(): "background" | "manual" | "off" {
 export function shouldSummarizeLifecycleTransitions(): boolean {
 	const value = (process.env.PI_MEMORY_SUMMARIZE_TRANSITIONS ?? "").toLowerCase();
 	return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+/**
+ * Exit summaries on real quit (Ctrl+D, /quit, session end) can be disabled
+ * with PI_MEMORY_EXIT_SUMMARY=0 (aliases: off/false/no). Default: enabled.
+ */
+export function isExitSummaryEnabled(): boolean {
+	const value = (process.env.PI_MEMORY_EXIT_SUMMARY ?? "").trim().toLowerCase();
+	return !(value === "0" || value === "off" || value === "false" || value === "no");
 }
 
 export function shouldSkipExitSummaryForReason(reason: string | undefined): boolean {
@@ -1406,7 +1446,7 @@ export default function (pi: ExtensionAPI) {
 		// /new, /resume, and /fork because that makes those transitions slow.
 		// Users who prefer the old behavior can opt in with
 		// PI_MEMORY_SUMMARIZE_TRANSITIONS=1.
-		if (shouldSkipExitSummaryForReason(shutdownReason)) {
+		if (shouldSkipExitSummaryForReason(shutdownReason) || !isExitSummaryEnabled()) {
 			exitSummaryReason = null;
 			if (updateTimer) {
 				clearTimeout(updateTimer);
@@ -2329,6 +2369,8 @@ export default function (pi: ExtensionAPI) {
 				`- PI_MEMORY_QMD_UPDATE: ${getQmdUpdateMode()}`,
 				`- PI_MEMORY_QMD_SEARCH_TIMEOUT_MS: ${getQmdSearchTimeoutMs()}`,
 				`- PI_MEMORY_DIR: ${process.env.PI_MEMORY_DIR ? "set" : "default"}`,
+				`- PI_MEMORY_EXIT_SUMMARY: ${isExitSummaryEnabled() ? "enabled" : "disabled"}`,
+				`- PI_MEMORY_EXIT_SUMMARY_MODEL: ${process.env.PI_MEMORY_EXIT_SUMMARY_MODEL?.trim() || "session model"}`,
 			);
 
 			return {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -32,6 +32,7 @@ import {
 	ensureQmdEmbed,
 	forgetBlocks,
 	getQmdSearchTimeoutMs,
+	isExitSummaryEnabled,
 	nowTimestamp,
 	parseScratchpad,
 	qmdCollectionInstructions,
@@ -1550,6 +1551,115 @@ describe("lifecycle hooks", () => {
 
 		expect(getApiKey).toHaveBeenCalled();
 		expect(fs.existsSync(dailyPath(todayStr()))).toBe(false);
+	});
+
+	// -- exit summary configurability (PI_MEMORY_EXIT_SUMMARY / PI_MEMORY_EXIT_SUMMARY_MODEL) --
+
+	describe("exit summary configurability", () => {
+		const fourMessageBranch = () => [
+			{
+				type: "message",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Please remember we chose dark mode." }],
+					timestamp: Date.now(),
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Noted, using it for the storage layer." }],
+					timestamp: Date.now(),
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Also migrate the config to match." }],
+					timestamp: Date.now(),
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Done — config migrated and tests pass." }],
+					timestamp: Date.now(),
+				},
+			},
+		];
+
+		let savedEnabled: string | undefined;
+		let savedModel: string | undefined;
+		beforeEach(() => {
+			savedEnabled = process.env.PI_MEMORY_EXIT_SUMMARY;
+			savedModel = process.env.PI_MEMORY_EXIT_SUMMARY_MODEL;
+		});
+		afterEach(() => {
+			if (savedEnabled === undefined) delete process.env.PI_MEMORY_EXIT_SUMMARY;
+			else process.env.PI_MEMORY_EXIT_SUMMARY = savedEnabled;
+			if (savedModel === undefined) delete process.env.PI_MEMORY_EXIT_SUMMARY_MODEL;
+			else process.env.PI_MEMORY_EXIT_SUMMARY_MODEL = savedModel;
+		});
+
+		test("PI_MEMORY_EXIT_SUMMARY=0 skips the exit summary on real quit", async () => {
+			process.env.PI_MEMORY_EXIT_SUMMARY = "0";
+			const getApiKey = mock(async () => "key");
+			const ctx = createShutdownCtx({
+				branch: fourMessageBranch(),
+				model: { provider: "openai", id: "gpt-4o-mini" },
+				modelRegistry: { getApiKey },
+			});
+
+			await hooks.session_shutdown({ reason: "quit" }, ctx);
+
+			expect(getApiKey).not.toHaveBeenCalled();
+			expect(fs.existsSync(dailyPath(todayStr()))).toBe(false);
+		});
+
+		test("PI_MEMORY_EXIT_SUMMARY=off (and other aliases) also disable", async () => {
+			for (const value of ["off", "false", "no"]) {
+				process.env.PI_MEMORY_EXIT_SUMMARY = value;
+				expect(isExitSummaryEnabled()).toBe(false);
+			}
+			delete process.env.PI_MEMORY_EXIT_SUMMARY;
+			expect(isExitSummaryEnabled()).toBe(true);
+		});
+
+		test("PI_MEMORY_EXIT_SUMMARY_MODEL routes the summary to the configured model", async () => {
+			process.env.PI_MEMORY_EXIT_SUMMARY_MODEL = "anthropic/claude-haiku-4";
+			const overrideModel = { provider: "anthropic", id: "claude-haiku-4" };
+			const find = mock((_provider: string, _id: string) => overrideModel);
+			const getApiKey = mock(async (_model: unknown) => undefined);
+			const ctx = createShutdownCtx({
+				branch: fourMessageBranch(),
+				model: { provider: "openai", id: "gpt-4o-mini" },
+				modelRegistry: { find, getApiKey },
+			});
+
+			await hooks.session_shutdown({ reason: "quit" }, ctx);
+
+			expect(find).toHaveBeenCalledWith("anthropic", "claude-haiku-4");
+			expect(getApiKey).toHaveBeenCalledWith(overrideModel);
+		});
+
+		test("unresolvable PI_MEMORY_EXIT_SUMMARY_MODEL falls back to the session model", async () => {
+			process.env.PI_MEMORY_EXIT_SUMMARY_MODEL = "nonexistent/no-such-model";
+			const sessionModel = { provider: "openai", id: "gpt-4o-mini" };
+			const find = mock((_provider: string, _id: string) => undefined);
+			const getApiKey = mock(async (_model: unknown) => undefined);
+			const ctx = createShutdownCtx({
+				branch: fourMessageBranch(),
+				model: sessionModel,
+				modelRegistry: { find, getApiKey },
+			});
+
+			await hooks.session_shutdown({ reason: "quit" }, ctx);
+
+			expect(getApiKey).toHaveBeenCalledWith(sessionModel);
+		});
 	});
 
 	// -- session_before_compact --


### PR DESCRIPTION
Implements the opt-out requested in #26, plus the model override discussed there. The hardening fixes from the issue's follow-up comment will come as a separate PR.

## What

Two new env vars for the exit summary that runs on real quit (Ctrl+D, `/quit`, session end):

- **`PI_MEMORY_EXIT_SUMMARY=0`** (aliases `off`/`false`/`no`): skips the exit summary entirely — no LLM call and no `qmd update`, so quitting is instant. Lifecycle-transition behavior (`/reload` etc. skipping by default) is unchanged, and explicit `memory_write` during sessions is unaffected.
- **`PI_MEMORY_EXIT_SUMMARY_MODEL=provider/model-id`**: routes the summary to a configured model (e.g. a cheaper/faster one) instead of always using the session's active model. Unresolvable specs fall back to the session model with a warning. `resolveExitSummaryApiKey` now takes the model as a parameter so the override model's credentials are used.

Both surface in the `memory_status` configuration section, the README env table, and the changelog.

## Tests (TDD per AGENTS.md)

Baseline before edits: `bun test test/unit.test.ts` → 172 pass; `tsc --noEmit` and `biome check` clean.

New tests (added red, then green):

- `PI_MEMORY_EXIT_SUMMARY=0` on a real quit with a summarizable session: no API-key lookup, no daily-log write
- alias values (`off`/`false`/`no`) disable; unset defaults to enabled (`isExitSummaryEnabled()`)
- `PI_MEMORY_EXIT_SUMMARY_MODEL` resolves via `modelRegistry.find(provider, id)` and the API key is requested for the override model, not the session model
- unresolvable override falls back to the session model

After: **176 pass, 0 fail**; `tsc --noEmit` and `biome check` clean.

Refs #26