### PR TITLE
chore: release 0.4.2

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "22.19.0"
           cache: npm
           registry-url: "https://registry.npmjs.org"
       - uses: oven-sh/setup-bun@v2
@@ -45,4 +46,4 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
-      - run: npm publish
+      - run: npm publish --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.2] — 2026-08-10
+
 ### Added
 
 - `PI_MEMORY_EXIT_SUMMARY=0` (aliases: `off`/`false`/`no`) disables the exit
@@ -28,6 +30,13 @@ follows [Semantic Versioning](https://semver.org/).
   Pi core awaits shutdown handlers with no timeout, so a hanging provider
   previously blocked quitting indefinitely. On expiry nothing is persisted.
   (#26)
+
+### Changed
+
+- npm releases now run on the package's supported Node.js 22.19 runtime and
+  publish provenance attestations after lint, build, and unit-test gates pass.
+
+## [0.4.1] — 2026-08-08
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-memory",
-	"version": "0.4.0",
+	"version": "0.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-memory",
-			"version": "0.4.0",
+			"version": "0.4.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-memory",
-	"version": "0.4.0",
+	"version": "0.4.2",
 	"description": "Pi coding agent extension for memory with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "index.ts",
 	"type": "module",

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -156,6 +156,7 @@ describe("runtime package scope", () => {
 describe("GitHub Actions workflows", () => {
 	const ciWorkflow = fs.readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf-8");
 	const e2eWorkflow = fs.readFileSync(new URL("../.github/workflows/e2e.yml", import.meta.url), "utf-8");
+	const publishWorkflow = fs.readFileSync(new URL("../.github/workflows/publish-npm.yml", import.meta.url), "utf-8");
 	const qmdWorkflow = fs.readFileSync(new URL("../.github/workflows/windows-qmd-smoke.yml", import.meta.url), "utf-8");
 
 	test("runs feature-branch CI once and cancels superseded runs", () => {
@@ -187,6 +188,18 @@ describe("GitHub Actions workflows", () => {
 		expect(e2eWorkflow).toContain("workflow_dispatch:");
 		expect(e2eWorkflow).not.toContain("pull_request:");
 		expect(e2eWorkflow).toContain("run: npm run test:e2e");
+	});
+
+	test("publishes matching release tags on the supported Node runtime with provenance", () => {
+		expect(publishWorkflow).toContain('tags:\n      - "v*"');
+		expect(publishWorkflow).toContain(`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}`);
+		expect(publishWorkflow).toContain('node-version: "22.19.0"');
+		expect(publishWorkflow).toContain("id-token: write");
+		expect(publishWorkflow).toContain(`tag="\${GITHUB_REF_NAME#v}"`);
+		expect(publishWorkflow).toContain("npm run lint");
+		expect(publishWorkflow).toContain("npm run build");
+		expect(publishWorkflow).toContain("npm test");
+		expect(publishWorkflow).toContain("npm publish --provenance");
 	});
 });
 


### PR DESCRIPTION
## Summary

- release the exit-summary configuration and shutdown hardening as `0.4.2`
- run npm publishing on Node.js 22.19 with provenance attestations
- add regression coverage for the tag/version/test gates in the publish workflow

## Validation

- `npm test` — 182 passed
- `npm run build` — passed
- `npm run lint` — passed
- `npm pack --dry-run --json` — package contents verified

## Publishing

After merge, tag the merge commit as `v0.4.2`. The tag-gated `publish-npm.yml` workflow will verify the tag/package version match and publish using the `NPM_TOKEN` repository secret.
